### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: "/"
+  directory: "/finish"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50
+- package-ecosystem: maven
+  directory: "/start"
   schedule:
     interval: monthly
   open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -3,7 +3,6 @@ name: Add PRs to Dependabot PRs dashboard
 on:
   pull_request:
     types:
-      - opened
       - labeled
 
 jobs:

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         uses: github/super-linter@v3.17.0
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: ./tools/pr-checker/linters/
           DEFAULT_BRANCH: prod

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,4 @@
-// INSTRUCTION: Please remove all comments that start INSTRUCTION prior to commit. Most comments should be removed, although not the copyright.
-// INSTRUCTION: The copyright statement must appear at the top of the file
-//
-// Copyright (c) 2019, 2023 IBM Corporation and others.
+// Copyright (c) 2019, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -14,7 +11,7 @@
 :page-duration: 30 minutes
 :page-releasedate: 2019-09-13
 :page-description: Explore how to use MicroProfile Fault Tolerance together with Istio Fault Tolerance
-:page-tags: ['MicroProfile', 'Kubernetes', 'Docker']
+:page-tags: ['microprofile', 'kubernetes', 'docker']
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['istio-intro', 'microprofile-fallback', `iguide-retry-timeout`]
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
@@ -345,7 +342,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
+kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9090
 ```
 --
 
@@ -353,7 +350,7 @@ kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9080"
+kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9090"
 ```
 --
 
@@ -429,7 +426,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
+kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9090
 ```
 --
 
@@ -437,7 +434,7 @@ kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9080"
+kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9090"
 ```
 --
 
@@ -537,7 +534,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
+kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9090
 ```
 --
 
@@ -545,7 +542,7 @@ kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9080"
+kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9090"
 ```
 --
 
@@ -659,7 +656,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
+kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9090
 ```
 --
 
@@ -667,7 +664,7 @@ kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9080"
+kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9090"
 ```
 --
 
@@ -811,7 +808,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
+kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9090
 ```
 --
 
@@ -819,7 +816,7 @@ kubectl logs [system-pod-name] -c istio-proxy | grep -c system-service:9080
 --
 [role=command]
 ```
-kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9080"
+kubectl logs [system-pod-name] -c istio-proxy | find /C "system-service:9090"
 ```
 --
 

--- a/README.adoc
+++ b/README.adoc
@@ -873,7 +873,7 @@ include::{common-includes}/os-tabs.adoc[]
 --
 [role=command]
 ```
-istioctl x uninstall --purge
+istioctl uninstall --purge
 ```
 --
 
@@ -881,7 +881,7 @@ istioctl x uninstall --purge
 --
 [role=command]
 ```
-istioctl x uninstall --purge
+istioctl uninstall --purge
 ```
 --
 
@@ -889,7 +889,7 @@ istioctl x uninstall --purge
 --
 [role=command]
 ```
-istioctl x uninstall --purge
+istioctl uninstall --purge
 ```
 Perform the following steps to return your environment to a clean state.
 

--- a/README.adoc
+++ b/README.adoc
@@ -102,7 +102,7 @@ include::{common-includes}/gitclone.adoc[]
 // Preparing your cluster and deploying Istio
 // =================================================================================================
 
-:minikube-start: minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.19.0
+:minikube-start: minikube start --memory=8192 --cpus=4
 :docker-desktop-description: Ensure that you have enough memory allocated to your Docker Desktop enviornment. 8GB is recommended but 4GB should be adequate if you don't have enough RAM.
 :minikube-description: The memory flag allocates 8GB of memory to your Minikube cluster. If you don't have enough RAM, then 4GB should be adequate.
 [role=command]

--- a/README.adoc
+++ b/README.adoc
@@ -312,7 +312,8 @@ Finally, click the blue `Send` button to make the request.
 --
 [role=command]
 ```
-curl -H Host:inventory.example.com http://`minikube ip`:31380/inventory/systems/system-service -I
+export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+curl -H Host:inventory.example.com http://`minikube ip`:$INGRESS_PORT/inventory/systems/system-service -I
 ```
 --
 
@@ -397,7 +398,7 @@ If the `curl` command is unavailable, then use https://www.getpostman.com/[Postm
 --
 [role=command]
 ```
-curl -H Host:inventory.example.com http://`minikube ip`:31380/inventory/systems/system-service -I
+curl -H Host:inventory.example.com http://`minikube ip`:$INGRESS_PORT/inventory/systems/system-service -I
 ```
 --
 
@@ -519,7 +520,7 @@ If the `curl` command is unavailable, then use https://www.getpostman.com/[Postm
 --
 [role=command]
 ```
-curl -H Host:inventory.example.com http://`minikube ip`:31380/inventory/systems/system-service -I
+curl -H Host:inventory.example.com http://`minikube ip`:$INGRESS_PORT/inventory/systems/system-service -I
 ```
 --
 
@@ -641,7 +642,7 @@ If the `curl` command is unavailable, then use https://www.getpostman.com/[Postm
 --
 [role=command]
 ```
-curl -H Host:inventory.example.com http://`minikube ip`:31380/inventory/systems/system-service -I
+curl -H Host:inventory.example.com http://`minikube ip`:$INGRESS_PORT/inventory/systems/system-service -I
 ```
 --
 
@@ -778,7 +779,7 @@ If the `curl` command is unavailable, then use https://www.getpostman.com/[Postm
 --
 [role=command]
 ```
-curl -H Host:inventory.example.com http://`minikube ip`:31380/inventory/systems/system-service -I
+curl -H Host:inventory.example.com http://`minikube ip`:$INGRESS_PORT/inventory/systems/system-service -I
 ```
 --
 

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -14,10 +14,10 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9444</liberty.var.default.https.port>
-        <liberty.var.system.http.port>9080</liberty.var.system.http.port>
-        <liberty.var.system.https.port>9443</liberty.var.system.https.port>
+        <liberty.var.http.port>9091</liberty.var.http.port>
+        <liberty.var.https.port>9454</liberty.var.https.port>
+        <liberty.var.system.http.port>9090</liberty.var.system.http.port>
+        <liberty.var.system.https.port>9453</liberty.var.system.https.port>
     </properties>
 
     <dependencies>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -51,19 +51,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -5,19 +5,19 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>mpRestClient-3.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
     <!-- tag::mpFaultTolerance[] -->
     <feature>mpFaultTolerance-4.0</feature>
     <!-- end::mpFaultTolerance[] -->
   </featureManager>
 
-  <variable name="system.http.port" defaultValue="9080" />
-  <variable name="system.https.port" defaultValue="9443" />
-  <variable name="default.http.port" defaultValue="9081" />
-  <variable name="default.https.port" defaultValue="9444" />
+  <variable name="system.http.port" defaultValue="9090" />
+  <variable name="system.https.port" defaultValue="9453" />
+  <variable name="http.port" defaultValue="9091" />
+  <variable name="https.port" defaultValue="9454" />
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-istio-retry-fallback-inventory.war" contextRoot="/"/>
 

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
             <p>
                 For more information about the features used in this application, see the Open Liberty documentation:
                 <ul>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#mpFaultTolerance-4.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Fault Tolerance 4.0</a></li>
                 </ul>

--- a/finish/services.yaml
+++ b/finish/services.yaml
@@ -1,5 +1,5 @@
 # tag::gateway[]
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: sys-app-gateway

--- a/finish/services.yaml
+++ b/finish/services.yaml
@@ -1,5 +1,5 @@
 # tag::gateway[]
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: sys-app-gateway

--- a/finish/services.yaml
+++ b/finish/services.yaml
@@ -24,7 +24,7 @@ metadata:
     app: system
 spec:
   ports:
-  - port: 9080
+  - port: 9090
     name: http
   selector:
     app: system
@@ -37,7 +37,7 @@ metadata:
     app: inventory
 spec:
   ports:
-  - port: 9081
+  - port: 9091
     name: http
   selector:
     app: inventory
@@ -61,7 +61,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,7 +84,7 @@ spec:
         image: inventory:1.0-SNAPSHOT
         # end::invImage[]
         ports:
-        - containerPort: 9081
+        - containerPort: 9091
         # tag::invConfig[]
         envFrom:
         - configMapRef:

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -47,19 +47,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080" />
-  <variable name="default.https.port" defaultValue="9443" />
+  <variable name="http.port" defaultValue="9090" />
+  <variable name="https.port" defaultValue="9453" />
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-istio-retry-fallback-system.war" contextRoot="/"/>
 </server>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
             <p>
                 For more information about the features used in this application, see the Open Liberty documentation:
                 <ul>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/finish/traffic.yaml
+++ b/finish/traffic.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: system-virtual-service

--- a/finish/traffic.yaml
+++ b/finish/traffic.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: system-virtual-service

--- a/finish/traffic.yaml
+++ b/finish/traffic.yaml
@@ -11,7 +11,7 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -28,7 +28,7 @@ spec:
   - route:
     - destination:
         port:
-          number: 9081
+          number: 9091
         host: inventory-service
     # tag::istioRetry[]
     retries:

--- a/scripts/installIstio.sh
+++ b/scripts/installIstio.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ISTIO_LATEST=1.11.2
+ISTIO_LATEST=1.20.0
 
 apt install socat
 

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -67,7 +67,7 @@ fi
 
 sleep 30
 
-COUNT=$(kubectl logs "$SYSTEM" -c istio-proxy | grep -c system-service:9080)
+COUNT=$(kubectl logs "$SYSTEM" -c istio-proxy | grep -c system-service:9090)
 
 echo COUNT="$COUNT"
 

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -14,10 +14,10 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9444</liberty.var.default.https.port>
-        <liberty.var.system.http.port>9080</liberty.var.system.http.port>
-        <liberty.var.system.https.port>9443</liberty.var.system.https.port>
+        <liberty.var.http.port>9091</liberty.var.http.port>
+        <liberty.var.https.port>9454</liberty.var.https.port>
+        <liberty.var.system.http.port>9090</liberty.var.system.http.port>
+        <liberty.var.system.https.port>9453</liberty.var.system.https.port>
     </properties>
 
     <dependencies>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -49,19 +49,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -5,19 +5,19 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>mpRestClient-3.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
     <!-- tag::mpFaultTolerance[] -->
     <feature>mpFaultTolerance-4.0</feature>
     <!-- end::mpFaultTolerance[] -->
   </featureManager>
 
-  <variable name="system.http.port" defaultValue="9080" />
-  <variable name="system.https.port" defaultValue="9443" />
-  <variable name="default.http.port" defaultValue="9081" />
-  <variable name="default.https.port" defaultValue="9444" />
+  <variable name="system.http.port" defaultValue="9090" />
+  <variable name="system.https.port" defaultValue="9453" />
+  <variable name="http.port" defaultValue="9091" />
+  <variable name="https.port" defaultValue="9454" />
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-istio-retry-fallback-inventory.war" contextRoot="/"/>
 

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
             <p>
                 For more information about the features used in this application, see the Open Liberty documentation:
                 <ul>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#mpFaultTolerance-4.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Fault Tolerance 4.0</a></li>
                 </ul>

--- a/start/services.yaml
+++ b/start/services.yaml
@@ -22,7 +22,7 @@ metadata:
     app: system
 spec:
   ports:
-  - port: 9080
+  - port: 9090
     name: http
   selector:
     app: system
@@ -35,7 +35,7 @@ metadata:
     app: inventory
 spec:
   ports:
-  - port: 9081
+  - port: 9091
     name: http
   selector:
     app: inventory
@@ -59,7 +59,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,4 +80,4 @@ spec:
       - name: inventory-container
         image: inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9081
+        - containerPort: 9091

--- a/start/services.yaml
+++ b/start/services.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: sys-app-gateway

--- a/start/services.yaml
+++ b/start/services.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: sys-app-gateway

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -47,19 +47,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080" />
-  <variable name="default.https.port" defaultValue="9443" />
+  <variable name="http.port" defaultValue="9090" />
+  <variable name="https.port" defaultValue="9453" />
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-istio-retry-fallback-system.war" contextRoot="/"/>
 </server>

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
             <p>
                 For more information about the features used in this application, see the Open Liberty documentation:
                 <ul>
-                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+                    <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
                     <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/start/traffic.yaml
+++ b/start/traffic.yaml
@@ -11,7 +11,7 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -27,5 +27,5 @@ spec:
   - route:
     - destination:
         port:
-          number: 9081
+          number: 9091
         host: inventory-service

--- a/start/traffic.yaml
+++ b/start/traffic.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: system-virtual-service

--- a/start/traffic.yaml
+++ b/start/traffic.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: system-virtual-service


### PR DESCRIPTION
address issues:
- https://github.com/OpenLiberty/guides-common/issues/1021
- #122 

### Review changes
- [x] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [x] server.xml
  - feature version
- [x] index.html
  - feature version
- [x] update lgdev with `version-update-mp61` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

